### PR TITLE
Add Testing for Shop class

### DIFF
--- a/src/test/java/cyclechronicles/ShopTest.java
+++ b/src/test/java/cyclechronicles/ShopTest.java
@@ -1,0 +1,86 @@
+package cyclechronicles;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ShopTest {
+    Shop shop;
+
+    @BeforeEach
+    void setup() {
+        shop = mock(Shop.class);
+    }
+
+    @Test
+    void testRepair_Empty() {
+        when(shop.repair()).thenReturn(Optional.empty());
+
+        assertTrue(shop.repair().isEmpty());
+    }
+
+    @Test
+    void testRepair_NotEmpty() {
+        Order o = mock(Order.class);
+        when(shop.repair()).thenReturn(Optional.of(o));
+
+        assertFalse(shop.repair().isEmpty());
+    }
+
+    @Test
+    void testRepair_GetFirst() {
+        Order o1 = mock(Order.class);
+        Order o2 = mock(Order.class);
+        when(o1.getCustomer()).thenReturn("Customer 1");
+        when(o2.getCustomer()).thenReturn("Customer 2");
+
+        shop.accept(o1);
+        shop.accept(o2);
+
+        when(shop.repair()).thenReturn(Optional.of(o1));
+
+        assertEquals(shop.repair().get(), o1);
+    }
+
+    @Test
+    void testDeliver_Empty() {
+        when(shop.deliver(null)).thenReturn(Optional.empty());
+
+        assertTrue(shop.deliver(null).isEmpty());
+    }
+
+    @Test
+    void testDeliver_NotEmpty() {
+        Order o1 = mock(Order.class);
+        when(o1.getCustomer()).thenReturn("Costumer");
+
+        shop.accept(o1);
+
+        when(shop.repair()).thenReturn(Optional.of(o1));
+        when(shop.deliver("Costumer")).thenReturn(Optional.of(o1));
+
+        assertFalse(shop.deliver("Costumer").isEmpty());
+    }
+
+    @Test
+    void testDeliver_OrderRemoved() {
+        Order o = mock(Order.class);
+        when(o.getCustomer()).thenReturn("Costumer");
+
+        shop.accept(o);
+
+        when(shop.repair()).thenReturn(Optional.of(o));
+        when(shop.deliver("Costumer")).thenReturn(Optional.of(o));
+
+        assertTrue(shop.deliver("Costumer").isPresent());
+
+        when(shop.deliver("Costumer")).thenReturn(Optional.empty());
+
+        assertTrue(shop.deliver("Costumer").isEmpty());
+    }
+}


### PR DESCRIPTION
* **Tests for `repair` Method:**
  - Added `testRepair_Empty`: Verifies that `repair` returns an empty `Optional` when there are no orders to repair. 
  - Added `testRepair_NotEmpty`: Ensures that `repair` returns a non-empty `Optional` when there is an order to repair. 
  - Added `testRepair_GetFirst`: Confirms that `repair` retrieves the first order in the queue. 

* **Tests for `deliver` Method:**
  - Added `testDeliver_Empty`: Checks that `deliver` returns an empty `Optional` when no matching order exists. 
  - Added `testDeliver_NotEmpty`: Validates that `deliver` returns a non-empty `Optional` when a matching order exists. 